### PR TITLE
Set max width for title image

### DIFF
--- a/style.css
+++ b/style.css
@@ -279,6 +279,7 @@ h1, h2, h3, p, div { padding: 0 5px; }
 }
 #top-title img {
   width: 300px;
+  max-width: 100%;
 }
 #top-subtitle {
   font-size: 16px;


### PR DESCRIPTION
This assures the title image will no longer be partly out of the visible display, and thus won't cause a scrollbar to appear, because the part is broader than the viewport width.

Fixes #39 